### PR TITLE
Repositories overview and actions

### DIFF
--- a/records/0001-clean-organization.md
+++ b/records/0001-clean-organization.md
@@ -1,0 +1,116 @@
+# Cleanup Organization
+
+With the new efforts that are starting, we want to provide a good ecosystem for all.
+For that, we need to clean and decide which repositories needs to be deleted, archived or which one need to be stopped.
+
+If we choose to archive to packages, they need to be deprecated on npmjs.org aswell.
+
+## express
+
+| Name  | Download (weekly, million)  | Comment  | Action  |
+|---|---|---|---|
+| [.github](https://github.com/expressjs/.github)  | N/A  | specific github repository  | remove  |
+| [Admin](https://github.com/expressjs/Admin)  | N/A  |  just created  | keep and pin  |
+| [Badgeboard](https://github.com/expressjs/badgeboard)  | N/A |   | keep  |
+| [basic-auth-connect](https://github.com/expressjs/basic-auth-connect)  | 0.5  | 10 years old  | update and keep OR archive  |
+| [body-parser](https://github.com/expressjs/body-parser)  | 38.5  | -  | keep  |
+| [compression](https://github.com/expressjs/compression)  | 19.4  | -  | keep  |
+| [connect-markdown](https://github.com/expressjs/connect-markdown)  | 0 (15)  | 11 years old  | archive  |
+| [connect-multiparty](https://github.com/expressjs/connect-multiparty)  | 0.08  | 5 years old  | archive  |
+| [connect-rid](https://github.com/expressjs/connect-rid)  | 0 (206)  | 10 years old  | archive  |
+| [cookie-parser](https://github.com/expressjs/cookie-parser)  | 3.2  | -  | keep  |
+| [cookie-session](https://github.com/expressjs/cookie-session)  | 0.22  | -  | keep  |
+| [cors](https://github.com/expressjs/cors)  | 11.4  | 5 years old  | keep  |
+| [discussion](https://github.com/expressjs/discussions)  | N/A  | -  | keep  |
+| [domain-middleware](https://github.com/expressjs/domain-middleware)  | 0.001  | 11 years old  | archive  |
+| [error-handler](https://github.com/expressjs/errorhandler)  | 2.1  | 5 years old  | keep  |
+| [examples](https://github.com/expressjs/examples)  | N/A  | -  | remove  |
+| [express](https://github.com/expressjs/express)  | 29.5  | -  | keep  |
+| [express-expose](https://github.com/expressjs/express-expose)  | 0.002  | 9 years old  | archive  |
+| [express-namespace](https://github.com/expressjs/express-namespace)  | 0.0008  | dead project  | archive  |
+| [express-paginate](https://github.com/expressjs/express-paginate)  | 0.004  | -  | archive  |
+| [expressjs.com](https://github.com/expressjs/expressjs.com)  | N/A  | website  | keep  |
+| [express.github.io](https://github.com/expressjs/expressjs.github.io)  | N/A  | doc  | archive  |
+| [flash](https://github.com/expressjs/flash)  | 0.001  | 9 years old  | remove  |
+| [generator](https://github.com/expressjs/generator)  | 0.008  | CLI  | keep  |
+| [method-override](https://github.com/expressjs/method-override)  | 0.9  | 6 years old  | keep  |
+| [mime-extended](https://github.com/expressjs/mime-extended)  | 0 (29)  | 10 years old  | archive  |
+| [morgan](https://github.com/expressjs/morgan)  | 4.6  | -  | keep  |
+| [multer](https://github.com/expressjs/multer)  | 4.6  | -  | keep  |
+| [response-time](https://github.com/expressjs/response-time)  | 0.33  | 7 years old  | update and keep OR archive  |
+| [restfull-router](https://github.com/expressjs/restful-router)  | 0 (1)  | 11 years old  | archive  |
+| [routification](https://github.com/expressjs/routification)  | 0 (27)  | 10 years old  | archive  |
+| [security](https://github.com/expressjs/security)  | N/A  | -  | remove  |
+| [serve-favicon](https://github.com/expressjs/serve-favicon)  | 3  | 6 years old  | keep  |
+| [serve-index](https://github.com/expressjs/serve-index)  | 11.8  | 6 years old   | keep  |
+| [serve-static](https://github.com/expressjs/serve-static)  | 30.8  | -  | keep  |
+| [session](https://github.com/expressjs/session)  | 2.3  | express-session  | keep  |
+| [set-type](https://github.com/expressjs/set-type)  | 0 (30)  | deprecated  | archive  |
+| [statusboard](https://github.com/expressjs/statusboard)  | N/A  | N/A  | keep  |
+| [timeout](https://github.com/expressjs/timeout)  | 0.22  | 7 years old  | update and keep OR archive  |
+| [urlrouter](https://github.com/expressjs/urlrouter)  | 0 (142)  | 10 years old  | archive  |
+| [vhost](https://github.com/expressjs/vhost)  | 0.12  | 8 years old  | update and keep OR archive  |
+| [vhostess](https://github.com/expressjs/vhostess)  | 0 (22)  | 10 years old  | archive  |
+
+
+## pillarjs
+
+| Name  | Download (weekly, million)  | Comment  | Action  |
+|---|---|---|---|
+| [.github](https://github.com/pillarjs/.github)  | N/A  | -  | remove  |
+| [cookies](https://github.com/pillarjs/cookies)  | 2.2  | -  | keep  |
+| [csrf](https://github.com/pillarjs/csrf)  | 0.65  | 5 years old  | keep  |
+| [discussion](https://github.com/pillarjs/discussions)  | N/A  | backup issue  | remove  |
+| [encodeurl](https://github.com/pillarjs/encodeurl)  | 29.5  | 6 years old  | keep  |
+| [extended-proto](https://github.com/pillarjs/extend-proto)  | 0 (1)  | 8 years old  | archive  |
+| [finalhandler](https://github.com/pillarjs/finalhandler)  | 34.2  | -  | keep  |
+| [hbs](https://github.com/pillarjs/hbs)  | 0.16  | template engine  | keep  |
+| [multiparty](https://github.com/pillarjs/multiparty)  | 0.46  | not used by express  | keep  |
+| [node-frameworks](https://github.com/pillarjs/node-frameworks)  | N/A  | -  | archive  |
+| [parseurl](https://github.com/pillarjs/parseurl)  | 29.2  | 5 years old  |   |
+| [path-to-regexp](https://github.com/pillarjs/path-to-regexp)  | 51.3  | -  | keep  |
+| [pillarjs.github.io](https://github.com/pillarjs/pillarjs.github.io)  | N/A  | doc  | archive  |
+| [qs-strict](https://github.com/pillarjs/qs-strict)  | 0 (1)  | 9 years old  | archive  |
+| [request](https://github.com/pillarjs/request)  | N/A  | where?  | archive  |
+| [resolve-path](https://github.com/pillarjs/resolve-path)  | 0.8  | 6 years old  | update and keep OR archive  |
+| [router](https://github.com/pillarjs/router)  | 0.6  | -  | update and keep OR archive  |
+| [routington](https://github.com/pillarjs/routington)  | 0.001  | 9 years old  | archive  |
+| [send](https://github.com/pillarjs/send)  | 31.6  |  - | keep  |
+| [ssl-redirect](https://github.com/pillarjs/ssl-redirect)  | 0 (43)  | 9 years old  | archive  |
+| [templation](https://github.com/pillarjs/templation)  | 0 (27)  | 9 years old  |   |
+| [understanding-csrf](https://github.com/pillarjs/understanding-csrf)  | N/A  | reuse the doc  | archive  |
+| [view](https://github.com/pillarjs/views)  | N/A  | -  | remove  |
+
+## jshttp
+
+| Name  | Download (weekly, million)  | Comment  | Action  |
+|---|---|---|---|
+| [.github](https://github.com/jshttp/.github)  | N/A  | - | remove  |
+| [accepts](https://github.com/jshttp/accepts)  | 31.5  | -  | keep  |
+| [basic-auth](https://github.com/jshttp/basic-auth)  | 7.5  | 7 years old  | keep  |
+| [compressible](https://github.com/jshttp/compressible)  | 20.8  | - | keep  |
+| [content-disposition](https://github.com/jshttp/content-disposition)  | 32.1  | -  | keep  |
+| [content-type](https://github.com/jshttp/content-type)  | 30.4  | -  | keep  |
+| [cookie](https://github.com/jshttp/cookie)  | 49.8  | -  | keep  |
+| [etag](https://github.com/jshttp/etag)  | 29.2  | 6 years old  | keep  |
+| [forwarded](https://github.com/jshttp/forwarded)  | 28  | -  | keep  |
+| [fresh](https://github.com/jshttp/fresh)  | 29.5  | 6 years old  | keep  |
+| [http-assert](https://github.com/jshttp/http-assert)  | 1.5  | -  | keep  |
+| [http-errors](https://github.com/jshttp/http-errors)  | 55.7  | -  | keep  |
+| [http-push](https://github.com/jshttp/http-push)  | N/A  | -  | archive  |
+| [http-utils](https://github.com/jshttp/http-utils)  | 0 (14)  | -  | archive  |
+| [jshttp.github.io](https://github.com/jshttp/jshttp.github.io)  | N/A  | doc  | archive  |
+| [media-typer](https://github.com/jshttp/media-typer)  | 29  | 5 years old  | keep  |
+| [methods](https://github.com/jshttp/methods)  | 29.8  | 8 years old  | keep  |
+| [mime-db](https://github.com/jshttp/mime-db)  | 51.7  | -  | keep  |
+| [mime-types](https://github.com/jshttp/mime-types)  | 51  | -  | keep  |
+| [negotiator](https://github.com/jshttp/negotiator)  | 33.7  | -  | keep  |
+| [on-finished](https://github.com/jshttp/on-finished)  | 42.2  | -  | keep  |
+| [on-headers](https://github.com/jshttp/on-headers)  | 21.6  | 5 years old  | keep  |
+| [proxy-addr](https://github.com/jshttp/proxy-addr)  | 28.1  | -  | keep  |
+| [range-parser](https://github.com/jshttp/range-parser)  | 31  | 5 years old  | keep  |
+| [spdy-push](https://github.com/jshttp/spdy-push)  | 0 (35)  | 8 years old  | archive  |
+| [statuses](https://github.com/jshttp/statuses)  | 54.9  | -  | keep  |
+| [style-guide](https://github.com/jshttp/style-guide)  | N/A  | move to express/admin  | archive  |
+| [type-is](https://github.com/jshttp/type-is)  | 28.3  | 5 years old  | keep  |
+| [vary](https://github.com/jshttp/vary)  | 30  | 6 years old  | keep  |


### PR DESCRIPTION
Here is the list of all repositories that are currently marked as "active" in the three organizations (Express, Pillarjs, JShttp).
Some / a good numbers of them are empty or count for almost no downloads. 

This PR is to validate and agree between TC members which repositories can be archived or deleted completely (only if the repository was empty)

Some repositories are representing a small amont of download per week but still suffisant to discuss if we want to maintain them or deprecate them.

After all repositories are deleted or archived, it will be necessary to deprecate the packages on npmjs.org 