### PR TITLE
Create TC-Charter.md doc and charters dir

### DIFF
--- a/charters/TC-Charter.md
+++ b/charters/TC-Charter.md
@@ -1,0 +1,68 @@
+# Express Technical Committee (TC) Roles and Responsibilities
+
+## Introduction
+
+This document provides a comprehensive overview of the roles and responsibilities of the Express Technical Committee (TC). The TC plays a pivotal role in guiding the Express project's direction, ensuring its growth, stability, and alignment with the community's needs.
+
+## Purpose of the TC
+
+The TC is responsible for strategic planning, project oversight, and decision-making concerning the technical and operational aspects of the Express project. Its primary goal is to foster the development of Express as a robust, scalable, and secure framework for building web applications.
+
+## TC Membership
+
+### Eligibility
+
+- **Criteria**: Potential TC members should demonstrate significant contributions to the project, possess deep expertise in the Express framework and related technologies, and actively engage in the community. Eligibility is determined by contributions to code, documentation, community support, and involvement in project discussions.
+
+### Selection Process
+
+- **Nomination**: Any current TC member can nominate a committer to the TC. The nominee's contributions and engagement with the project are then evaluated through the TC's consensus-seeking process.
+- **Consensus Seeking**: As outlined in the Contributing.md, the TC strives for a resolution without open objections among members. If consensus cannot be reached, a majority vote is called. This process underscores that voting is a method of last resort.
+- **Membership Limits**: The TC will consist of a minimum of 3 active members and a maximum of 10, ensuring effective governance while maintaining a manageable group size for decision-making.
+
+### Responsibilities
+
+- **Active Participation**: TC members are expected to actively participate in discussions, contribute to decision-making processes, and engage in project governance. Participation in TC meetings is crucial, with the expectation to not miss more than three consecutive meetings.
+- **Maintaining Active Status**: Active participation within the last 6 months is required to maintain active TC status. Members not meeting this criterion are expected to step down or may be moved to inactive status, as detailed in the Contributing.md.
+- **Role of Project Captains**: Collaborate with project captains, providing guidance and suggestions to help move discussions forward towards consensus, especially on issues escalated to the TC.
+
+## Managing Inactivity and Transitions
+
+- **Inactivity and Transition**: The process for addressing inactivity and transitions within the TC, including stepping down and nominating replacements, aligns with the practices described in the Contributing.md. TC members stepping down are encouraged to nominate their replacements, ensuring continuity and knowledge transfer.
+- **Inactive Status**: Members who become inactive or do not meet the active participation requirements will be moved to inactive status but can nominate themselves back to active status if the TC has not reached its maximum size. Preference is given to returning inactive members in the event of a vacancy, provided the maximum size limit is respected.
+
+## Governance Structure
+
+Intentionally left blank
+
+## Decision-Making Process
+
+The TC uses a "consensus seeking" process for issues that are escalated to the TC.
+The group tries to find a resolution that has no open objections among TC members.
+
+If a consensus cannot be reached that has no objections then a majority wins vote
+is called. It is also expected that the majority of decisions made by the TC are via
+a consensus seeking process and that voting is only used as a last-resort.
+
+Resolution may involve returning the issue to project captains with suggestions on
+how to move forward towards a consensus. It is not expected that a meeting of the TC
+will resolve all issues on its agenda during that meeting and may prefer to continue
+the discussion happening among the project captains.
+
+## Responsibilities
+
+- **Technical Oversight**: Overseeing the technical direction of the project, including the review and approval of project enhancements, architecture decisions, and major releases.
+- **Community Engagement**: Fostering a healthy community by engaging with contributors, addressing conflicts, and ensuring a welcoming environment for new contributors.
+- **Financial and Legal Oversight**: If applicable, managing the project's finances, fundraising efforts, and adherence to legal and licensing obligations.
+- **Security**: Ensuring the project adheres to best practices for security, including regular audits, addressing vulnerabilities, and maintaining a security policy.
+- **Communications**: Representing the project in public forums, conferences, and within the wider Node.js and JavaScript communities.
+
+## Representation in Cross Project Council (CPC)
+
+Intentionally left blank
+
+## Amendments to the Charter
+
+This charter can be amended by the TC requiring at least two approvals and a minimum two
+week comment period for other TC members or CPC members to object.
+


### PR DESCRIPTION
same PR as https://github.com/expressjs/express/pull/5509 but targeted outside express repo since we are planning to move governance docs to a central repo

The name/location of the repo w/ governance docs may change, but I wanted to open this PR against the repo we currently are looking at governance docs in, so in case we do migrate from this repo we have PRs/source in once place.