### PR TITLE
Add Moderation Policy

### DIFF
--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -36,7 +36,7 @@ Any posts, comments, issues, or pull requests that violate the [Code of Conduct]
     address Code of Conduct violations.
 -   _Remove_ refers to the act of removing the configured write (commit)
     permissions for an individual Collaborator's GitHub account from _all_
-    s repositories as well as removing the account from
+    expressjs, jshttp, and pillarjs repositories as well as removing the account from
     the expressjs, jshttp, and pillarjs organizations membership.
 -   _Block_ refers to the act of prohibiting an individual GitHub account from any
     further participation in the expressjs, jshttp, and pillarjs organizations. A block may be

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -3,6 +3,8 @@
 If you are not a member and wish to submit a
 moderation request, please see [Requesting Moderation][].
 
+## Table of Contents
+
 -   [Applicability][]
 -   [Terms][]
 -   [Grounds for Moderation][]

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,0 +1,355 @@
+# Moderation policy
+
+If you are not a member of the s and wish to submit a
+moderation request, please see [Requesting Moderation][].
+
+-   [Applicability][]
+-   [Terms][]
+-   [Grounds for Moderation][]
+-   [Requesting Moderation][]
+-   [Consideration of Intent][]
+-   [Guidelines and Requirements][]
+    -   [Collaborator Posts][]
+    -   [Non-Collaborator Posts][]
+    -   [Temporary Interaction Limits][]
+    -   [Temporary and Indefinite Blocks][]
+-   [Privacy of the expressjs/moderation Repository][]
+-   [Moderation Team][]
+-   [Escalation of Issues][]
+-   [Modifications to This Policy][]
+
+## Applicability
+
+This policy applies to all repositories under these GitHub organizations: expressjs, jshttp, and pillarjs, as well as all working Groups.
+
+Any posts, comments, issues, or pull requests that violate the [Code of Conduct][] are subject to Moderation as defined in this policy.
+
+## Terms
+
+-   _Collaborator_ refers to any individual with configured triage role or higher
+    in any expressjs GitHub organization repository. See
+    [GitHub's Repository roles documentation][] for more information.
+-   _TC_ refers to the [expressjs Technical Committee][].
+-   _Post_ refers to the content and titles of any issue, pull request, comment,
+    discussion, or wiki page.
+-   _Moderate_ means to modify, lock, or delete one or more Posts to correct or
+    address Code of Conduct violations.
+-   _Remove_ refers to the act of removing the configured write (commit)
+    permissions for an individual Collaborator's GitHub account from _all_
+    s repositories as well as removing the account from
+    the s membership.
+-   _Block_ refers to the act of prohibiting an individual GitHub account from any
+    further participation in the s. A block may be
+    _temporary_ or _indefinite_.
+    -   This Moderation Policy applies only to blocking from the organization.
+        Individuals may choose to
+        [block other individuals from their personal GitHub accounts][]. This policy
+        does not restrict blocking from personal GitHub accounts.
+-   _Requester_ refers to an individual requesting Moderation on a Post.
+
+## Grounds for Moderation
+
+Any Post in violation of the expressjs [Code of Conduct][] is
+subject to Moderation.
+
+The Moderation Team is responsible for deciding what constitutes inappropriate
+behavior that may be subject to Moderation.
+
+## Requesting Moderation
+
+Anyone may request Moderation of a Post. Requesting Moderation of a Post can be
+accomplished in one of four ways:
+
+-   Via the [report@expressjs.com][] email address,
+-   Via private email to individual [Moderation Team members][],
+-   Via a new Post in the same thread as the Post being requested for Moderation,
+-   Via a new Post in the private expressjs/moderation repository.
+
+Note that Collaborators may Moderate non-Collaborator Posts at any time without
+submitting an initial request (see: [Non-Collaborator Posts][]).
+
+Use of the [report@expressjs.com][] email address -- or private email to individual
+Moderation Team members -- is appropriate when the individual requesting the
+Moderation does not feel comfortable directly or publicly making the request.
+All emails sent to the [report@expressjs.com][] address are currently forwarded
+to all members of the Moderation Team.
+
+When a request is sent by email to the [report@expressjs.com][] (or directly to a
+Moderation Team member) the moderation team must log the issue internally and
+report it periodically to the TC.
+
+Requests should contain as much information and context as possible, including
+the URL and a screenshot of the Post in question. Screenshots may be modified
+to obscure obscene or offensive content.
+
+External public venues or social media services such as Twitter must never be
+used to request Moderation.
+
+Collaborators must never discuss the specific details of a Moderation request
+in any public forum or any social media service outside of the expressjs GitHub
+Organizations.
+
+Note that quoting the original content of a Post within a Moderation request or
+expressjs/moderation repository issue is not a violation of the
+[Code of Conduct][]. However, discretion is advised when including such quotes
+in requests posted to public repositories.
+
+Requests for Moderation that do not appear to have been submitted in good faith
+with intent to address a legitimate [Code of Conduct][] violation will be
+ignored.
+
+## Consideration of Intent
+
+Before Moderating a Post, Collaborators should carefully consider the possible
+intent of the author. It may be that the author has simply made an error or is
+not yet familiar with the [Code of Conduct][]; or it may be that cultural
+differences exist, or that the author is unaware that certain content is
+inappropriate. In such cases, the author should be given an
+opportunity to correct any error that may have been made.
+
+Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse
+a Post from Moderation.
+
+## Guidelines and Requirements
+
+-   All Posts are expected to respect the expressjs [Code of Conduct][].
+-   Any Collaborator with triage permission to a given repository (except
+    expressjs/moderation) may Moderate Posts within that repository's issue tracker.
+    Only the Moderation team is allowed to moderate posts on expressjs/moderation.
+-   The Moderation Team serves as the final arbiter for all Moderation issues.
+-   Moderation Team members may Remove or Block an individual from the expressjs
+    GitHub Organizations.
+-   For any Removal or Blocking action, an issue describing the reasons for the
+    action, and identifying the Github account being acted upon, must be posted
+    to the Moderation Repository with an explanation provided by the Moderation
+    Team member performing the action.
+-   Any individual Blocked from the s will be recommended
+    for exclusion from any expressjs Foundation sponsored event or activity.
+-   Minor edits to the formatting of a Post or to correct typographical errors
+    are not "Moderation". Such edits and their intent must
+    still be documented with a short note indicating who made the edit and why.
+
+### Collaborator Posts
+
+-   Prior to Moderating any Post authored by a Collaborator, the author must be
+    given a reasonable opportunity to modify or remove the Post on their own.
+-   If the author of the Post disagrees that Moderation is required, the matter
+    can be escalated to the Moderation Team for resolution. In such cases, no
+    Moderation action may be taken until a decision by the Moderation Team is
+    made.
+-   When Moderating any Post authored by another Collaborator, the moderating
+    Collaborator must:
+    -   Explain the justification for Moderating the post,
+    -   Identify all changes made to the Post, and
+    -   Identify the steps previously taken to resolve the issue.
+    -   If the Moderation action included Blocking, an indication of whether the Block
+        is temporary or indefinite is required, along with an issue posted to the
+        moderation repository justifying the action.
+-   Explanations of Moderation actions on Collaborator Posts must be provided in:
+    -   A new post within the original thread, or
+    -   A new issue within the private expressjs/moderation repository.
+-   Any Collaborator habitually violating the Code of Conduct or this Moderation
+    policy may be Blocked temporarily or, in extreme cases, Removed and Blocked
+    indefinitely.
+
+### Non-Collaborator Posts
+
+-   Posts authored by non-Collaborators are always subject to immediate Moderation
+    by any Collaborator if the content is intentionally disruptive or in violation
+    of the [Code of Conduct][].
+-   When moderating non-Collaborator posts, the moderating Collaborator must:
+    -   Explain the justification for Moderating the post, and
+    -   Identify all changes made to the Post.
+    -   If the Moderation action included Blocking, an indication of whether the Block
+        is temporary or indefinite is required, along with a note justifying the
+        action.
+-   If an explanation of a Moderation action for a non-Collaborator Post is
+    provided, it must be provided in:
+    -   The original Post being modified (as replacement or appended content),
+    -   A new post within the original thread, or
+    -   A new issue within the private expressjs/moderation repository.
+-   Moderation of Posts authored by non-Collaborators may result in those
+    non-Collaborators being Blocked temporarily or indefinitely from further
+    participation in the expressjs GitHub organization.
+-   If it is clear that there is no intention to collaborate in good faith,
+    it is possible to hide comments of non-Collaborators. In that case there is
+    an exception to the reporting requirement described above.
+-   Accounts that are reasonably believed to be bots (other than bots authorized
+    by the TC) are subject to immediate Blocking.
+-   Issues, pull requests, discussions, and comments that are spam (job posting,
+    service advertising, etc.) are subject to immediate moderation.
+-   Collaborators may use the Hide feature in the GitHub interface for off-topic
+    posts by non-Collaborators.
+-   Moderation Team members and TC voting members can delete any issues or
+    comments posted by accounts that have been deleted by GitHub. These accounts
+    show up in the GitHub interface as user `ghost`. There is no need to
+    screenshot or document these deletions.
+
+There are a few examples of moderating non-Collaborator posts:
+
+Scenario 1:
+
+-   A non-Collaborator posts a comment that indicates that they are a bot.
+-   A collaborator sees the post and hides it.
+-   No further action is necessary.
+
+Scenario 2:
+
+-   A non-Collaborator posts a comment that is against the Code of Conduct.
+-   A Collaborator sees the comment and asks the author to edit it.
+-   The author refuses to edit their comment.
+-   The Collaborator deletes the comment and posts an issue in the moderation
+    repository explaining their actions.
+
+Scenario 3:
+
+-   A non-Collaborator opens a pull request with comments indicating they are a
+    bot.
+-   A Collaborator sees that pull requests, closes it, deletes the comments
+    and posts an issue in the moderation repository explaining their actions.
+-   A moderation team member sees the issue and decides to block the user from the
+    organization.
+
+Scenario 4:
+
+-   A non-Collaborator posts a comment on an old commit that is against the
+    Code of Conduct.
+-   A Collaborator sees the comment, takes a screenshot, and deletes it.
+-   The Collaborator posts an issue in the moderation repository explaining
+    their actions.
+
+### Temporary Interaction Limits
+
+The Moderation Team may, at their discretion, choose to enable [GitHub's
+Temporary Interaction Limits][] on any GitHub repository in the expressjs, jshttp, pillarjs GitHub
+Organizations.
+
+Any Collaborator may request that the Moderation Team enable the Temporary
+Interaction Limits by posting an issue to the moderation repository. If the
+Moderation Team chooses not to do so, then a comment explaining why that
+decision was made must be added to the moderation repository thread.
+
+### Temporary and Indefinite Blocks
+
+A Temporary Block is time limited, with the timeframe decided on by the Moderation
+Team at the time of issuing, depending on the severity of the issue. Recommended
+default options are 24-hour, 48-hour, and 7-day periods.
+
+An Indefinite Block is set for an unspecified period of time and may only be
+lifted for an individual through a simple majority vote of the Moderation
+Team.
+
+## Privacy of the expressjs/moderation Repository
+
+The expressjs/moderation Repository is used to discuss the potentially sensitive
+details of any specific moderation issue. The repository is private but
+accessible to all Collaborators. The details of any issue discussed within the
+expressjs/moderation repository are expected to remain confidential and are not to
+be discussed in any public forum or social media service.
+
+Any Collaborator found to be violating the privacy of the expressjs/moderation
+repository by repeatedly sharing or discussing the details of expressjs/moderation
+issues in any public forum or social media service risks being permanently
+removed from the expressjs GitHub organization.
+
+## Moderation Team
+
+The expressjs Moderation Team is tasked with enforcement of this policy.
+
+At least once per month, the Moderation Team must provide a report of all Moderation
+actions taken by the Moderation Team to the TC.
+
+_Requirements_
+
+-   Must be a Collaborator in the expressjs GitHub organization.
+-   Active participation in the expressjs/moderation repository.
+-   Show a commitment to the expressjs [Code of Conduct][].
+
+_Nomination_
+
+Moderation team members are Collaborators who self-nominate or are nominated by
+the TC. Team members must be approved by the TC with annual
+recertification. If there are no objections after seven days, the nomination is automatically
+accepted. If there are objections to a specific nomination, then a TC vote
+in favor of the nomination is required.
+
+_Onboarding_
+
+New Moderation Team members are onboarded with:
+
+-   an invite to expressjs Moderation Team channel in the OpenJS Slack
+-   permission changes made to GitHub to allow access to moderate
+-   a walkthrough of relevant processes, expectations, and documents by an existing Moderation Team member
+-   access to existing documents
+
+_Recertification_
+
+An annual recertification vote is required for all Moderation Team members.
+For an individual to be recertified, a TC vote in favor of recertification is required.
+
+_Departure_
+
+A TC vote is required to remove a moderator who has not resigned.
+
+_Resignation_
+
+At any time a Moderation Team member may notify the team that they will no longer be serving.
+Either the resigning member or an active member will file an issue notifying the Admin group
+that the team member is stepping down. An active team member will take necessary steps to
+remove resigning team member from respective permissions and private access.
+
+<!-- referenced from the CoC page -->
+
+<a id="current-members"></a>
+
+### Current Members of Moderation Team
+
+-   [IamLizu](https://github.com/IamLizu) -
+    **S M Mahmudul Hasan** <<he@smmahmudulhasan.com>> (he/him)
+
+## Escalation of Issues
+
+Moderation issue disputes not involving a TC voting member or Moderation Team
+member may be escalated to the TC for review by tagging the
+original issue, pull request, or associated expressjs/moderation repository
+tracking issue with the `moderation-review` label. Any such Moderation action
+may be overturned through a TC vote.
+
+TC or Moderation Team members directly involved in a Moderation
+issue (as either the Requester or author of the Post in question) are
+required to recuse themselves from any decisions required to resolve the
+issue.
+
+Moderation disputes involving TC or Moderation Team members,
+including questions of whether a TC or Moderation Team member has
+violated the Code of Conduct, _shall_ be referred to an Independent Mediator
+selected by the OpenJS Foundation.
+
+## Modifications to This Policy
+
+Modifications to this policy are subject to approval by the TC.
+When modifications are proposed, if there are no objections after
+72 hours, the modifications are accepted. If there any objections to
+any proposed change, a TC vote in favor of the change is required.
+
+[Code of Conduct]: https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md
+[expressjs Technical Committee]: https://github.com/expressjs/express/blob/master/Readme.md#tc-technical-committee
+[GitHub's Repository roles documentation]: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#repository-roles-for-organizations
+[GitHub's Temporary Interaction Limits]: https://github.com/blog/2370-introducing-temporary-interaction-limits
+[Applicability]: #applicability
+[Terms]: #terms
+[Grounds for Moderation]: #grounds-for-moderation
+[Requesting Moderation]: #requesting-moderation
+[Consideration of Intent]: #consideration-of-intent
+[Guidelines and Requirements]: #guidelines-and-requirements
+[Collaborator Posts]: #collaborator-posts
+[Non-Collaborator Posts]: #non-collaborator-posts
+[Temporary Interaction Limits]: #temporary-interaction-limits
+[Temporary and Indefinite Blocks]: #temporary-and-indefinite-blocks
+[Privacy of the expressjs/moderation Repository]: #privacy-of-the-expressjsmoderation-repository
+[Moderation Team]: #moderation-team
+[Moderation Team members]: #current-members
+[Escalation of Issues]: #escalation-of-issues
+[Modifications to This Policy]: #modifications-to-this-policy
+[report@expressjs.com]: mailto:report@expressjs.com
+[block other individuals from their personal GitHub accounts]: https://help.github.com/en/articles/blocking-a-user-from-your-personal-account

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -20,7 +20,7 @@ moderation request, please see [Requesting Moderation][].
 
 ## Applicability
 
-This policy applies to all repositories under these GitHub organizations: expressjs, jshttp, and pillarjs, as well as all working Groups.
+This policy applies to all repositories under these GitHub organizations: expressjs, jshttp, and pillarjs, as well as all Working Groups.
 
 Any posts, comments, issues, or pull requests that violate the [Code of Conduct][] are subject to Moderation as defined in this policy.
 
@@ -37,9 +37,9 @@ Any posts, comments, issues, or pull requests that violate the [Code of Conduct]
 -   _Remove_ refers to the act of removing the configured write (commit)
     permissions for an individual Collaborator's GitHub account from _all_
     s repositories as well as removing the account from
-    the s membership.
+    the expressjs, jshttp, and pillarjs organizations membership.
 -   _Block_ refers to the act of prohibiting an individual GitHub account from any
-    further participation in the s. A block may be
+    further participation in the expressjs, jshttp, and pillarjs organizations. A block may be
     _temporary_ or _indefinite_.
     -   This Moderation Policy applies only to blocking from the organization.
         Individuals may choose to
@@ -123,8 +123,8 @@ a Post from Moderation.
     action, and identifying the Github account being acted upon, must be posted
     to the Moderation Repository with an explanation provided by the Moderation
     Team member performing the action.
--   Any individual Blocked from the s will be recommended
-    for exclusion from any expressjs Foundation sponsored event or activity.
+-   Any individual Blocked from the expressjs, jshttp, and pillarjs organizations will be recommended
+    for exclusion from any OpenJS Foundation sponsored event or activity.
 -   Minor edits to the formatting of a Post or to correct typographical errors
     are not "Moderation". Such edits and their intent must
     still be documented with a short note indicating who made the edit and why.
@@ -221,8 +221,7 @@ Scenario 4:
 ### Temporary Interaction Limits
 
 The Moderation Team may, at their discretion, choose to enable [GitHub's
-Temporary Interaction Limits][] on any GitHub repository in the expressjs, jshttp, pillarjs GitHub
-Organizations.
+Temporary Interaction Limits][] on any GitHub repository in the expressjs, jshttp, and pillarjs GitHub Organizations.
 
 Any Collaborator may request that the Moderation Team enable the Temporary
 Interaction Limits by posting an issue to the moderation repository. If the

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,7 +1,6 @@
 # Moderation policy
 
-If you are not a member and wish to submit a
-moderation request, please see [Requesting Moderation][].
+If you are not a member and wish to submit a moderation request, please see [Requesting Moderation][].
 
 ## Table of Contents
 
@@ -22,170 +21,101 @@ moderation request, please see [Requesting Moderation][].
 
 ## Applicability
 
-This policy applies to all repositories under these GitHub organizations: expressjs, jshttp, and pillarjs, as well as all Working Groups.
+This policy applies to all repositories under these GitHub organizations: expressjs, jshttp, and pillarjs, Working Groups, Slack, Discord, and any other official communication channels. 
+
+Additionally, if your personal presence (e.g., social media profiles) mentions involvement in the project (e.g., "Express.js contributor" in your Twitter bio), the policy extends to your posts. This applies to all members of the Express.js, jshttp, and pillarjs GitHub organizations, including Collaborators, TC members, and the Moderation Team.
 
 Any posts, comments, issues, or pull requests that violate the [Code of Conduct][] are subject to Moderation as defined in this policy.
 
 ## Terms
 
--   _Collaborator_ refers to any individual with configured triage role or higher
-    in any expressjs GitHub organization repository. See
-    [GitHub's Repository roles documentation][] for more information.
+-   _Collaborator_ refers to any individual with configured triage role or higher in any expressjs GitHub organization repository. See [GitHub's Repository roles documentation][] for more information.
 -   _TC_ refers to the [expressjs Technical Committee][].
--   _Post_ refers to the content and titles of any issue, pull request, comment,
-    discussion, or wiki page.
--   _Moderate_ means to modify, lock, or delete one or more Posts to correct or
-    address Code of Conduct violations.
--   _Remove_ refers to the act of removing the configured write (commit)
-    permissions for an individual Collaborator's GitHub account from _all_
-    expressjs, jshttp, and pillarjs repositories as well as removing the account from
-    the expressjs, jshttp, and pillarjs organizations membership.
--   _Block_ refers to the act of prohibiting an individual GitHub account from any
-    further participation in the expressjs, jshttp, and pillarjs organizations. A block may be
-    _temporary_ or _indefinite_.
-    -   This Moderation Policy applies only to blocking from the organization.
-        Individuals may choose to
-        [block other individuals from their personal GitHub accounts][]. This policy
-        does not restrict blocking from personal GitHub accounts.
+-   _Post_ refers to the content and titles of any issue, pull request, comment, discussion, or wiki page.
+-   _Moderate_ means to modify, lock, or delete one or more Posts to correct or address Code of Conduct violations.
+-   _Remove_ refers to the act of removing the configured write (commit) permissions for an individual Collaborator's GitHub account from _all_ expressjs, jshttp, and pillarjs repositories as well as removing the account from the expressjs, jshttp, and pillarjs organizations membership.
+-   _Block_ refers to the act of prohibiting an individual GitHub account from any further participation in the expressjs, jshttp, and pillarjs organizations. A block may be _temporary_ or _indefinite_.
+    -   This Moderation Policy applies only to blocking from the organization. Individuals may choose to [block other individuals from their personal GitHub accounts][]. This policy does not restrict blocking from personal GitHub accounts.
 -   _Requester_ refers to an individual requesting Moderation on a Post.
 
 ## Grounds for Moderation
 
-Any Post in violation of the expressjs [Code of Conduct][] is
-subject to Moderation.
+Any Post in violation of the expressjs [Code of Conduct][] is subject to Moderation.
 
-The Moderation Team is responsible for deciding what constitutes inappropriate
-behavior that may be subject to Moderation.
+The Moderation Team is responsible for deciding what constitutes inappropriate behavior that may be subject to Moderation.
 
 ## Requesting Moderation
 
-Anyone may request Moderation of a Post. Requesting Moderation of a Post can be
-accomplished in one of four ways:
+Anyone may request Moderation of a Post. Requesting Moderation of a Post can be accomplished in one of four ways:
 
 -   Via the [report@expressjs.com][] email address,
 -   Via private email to individual [Moderation Team members][],
 -   Via a new Post in the same thread as the Post being requested for Moderation,
 -   Via a new Post in the private expressjs/moderation repository.
 
-Note that Collaborators may Moderate non-Collaborator Posts at any time without
-submitting an initial request (see: [Non-Collaborator Posts][]).
+Note that Collaborators may Moderate non-Collaborator Posts at any time without submitting an initial request (see: [Non-Collaborator Posts][]).
 
-Use of the [report@expressjs.com][] email address -- or private email to individual
-Moderation Team members -- is appropriate when the individual requesting the
-Moderation does not feel comfortable directly or publicly making the request.
-All emails sent to the [report@expressjs.com][] address are currently forwarded
-to all members of the Moderation Team.
+Use of the [report@expressjs.com][] email address -- or private email to individual Moderation Team members -- is appropriate when the individual requesting the Moderation does not feel comfortable directly or publicly making the request. All emails sent to the [report@expressjs.com][] address are currently forwarded to all members of the Moderation Team.
 
-When a request is sent by email to the [report@expressjs.com][] (or directly to a
-Moderation Team member) the moderation team must log the issue internally and
-report it periodically to the TC.
+When a request is sent by email to the [report@expressjs.com][] (or directly to a Moderation Team member) the moderation team must log the issue internally and report it periodically to the TC.
 
-Requests should contain as much information and context as possible, including
-the URL and a screenshot of the Post in question. Screenshots may be modified
-to obscure obscene or offensive content.
+Requests should contain as much information and context as possible, including the URL and a screenshot of the Post in question. Screenshots may be modified to obscure obscene or offensive content.
 
-External public venues or social media services such as Twitter must never be
-used to request Moderation.
+External public venues or social media services such as Twitter must never be used to request Moderation.
 
-Collaborators must never discuss the specific details of a Moderation request
-in any public forum or any social media service outside of the expressjs GitHub
-Organizations.
+Collaborators must never discuss the specific details of a Moderation request in any public forum or any social media service outside of the expressjs GitHub Organizations.
 
-Note that quoting the original content of a Post within a Moderation request or
-expressjs/moderation repository issue is not a violation of the
-[Code of Conduct][]. However, discretion is advised when including such quotes
-in requests posted to public repositories.
+Note that quoting the original content of a Post within a Moderation request or expressjs/moderation repository issue is not a violation of the [Code of Conduct][]. However, discretion is advised when including such quotes in requests posted to public repositories.
 
-Requests for Moderation that do not appear to have been submitted in good faith
-with intent to address a legitimate [Code of Conduct][] violation will be
-ignored.
+Requests for Moderation that do not appear to have been submitted in good faith with intent to address a legitimate [Code of Conduct][] violation will be ignored.
 
 ## Consideration of Intent
 
-Before Moderating a Post, Collaborators should carefully consider the possible
-intent of the author. It may be that the author has simply made an error or is
-not yet familiar with the [Code of Conduct][]; or it may be that cultural
-differences exist, or that the author is unaware that certain content is
-inappropriate. In such cases, the author should be given an
-opportunity to correct any error that may have been made.
+Before Moderating a Post, Collaborators should carefully consider the possible intent of the author. It may be that the author has simply made an error or is not yet familiar with the [Code of Conduct][]; or it may be that cultural differences exist, or that the author is unaware that certain content is inappropriate. In such cases, the author should be given an opportunity to correct any error that may have been made.
 
-Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse
-a Post from Moderation.
+Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse a Post from Moderation.
 
 ## Guidelines and Requirements
 
 -   All Posts are expected to respect the expressjs [Code of Conduct][].
--   Any Collaborator with triage permission to a given repository (except
-    expressjs/moderation) may Moderate Posts within that repository's issue tracker.
-    Only the Moderation team is allowed to moderate posts on expressjs/moderation.
+-   Any Collaborator with triage permission to a given repository (except expressjs/moderation) may Moderate Posts within that repository's issue tracker. Only the Moderation team is allowed to moderate posts on expressjs/moderation.
 -   The Moderation Team serves as the final arbiter for all Moderation issues.
--   Moderation Team members may Remove or Block an individual from the expressjs
-    GitHub Organizations.
--   For any Removal or Blocking action, an issue describing the reasons for the
-    action, and identifying the Github account being acted upon, must be posted
-    to the Moderation Repository with an explanation provided by the Moderation
-    Team member performing the action.
--   Any individual Blocked from the expressjs, jshttp, and pillarjs organizations will be recommended
-    for exclusion from any OpenJS Foundation sponsored event or activity.
--   Minor edits to the formatting of a Post or to correct typographical errors
-    are not "Moderation". Such edits and their intent must
-    still be documented with a short note indicating who made the edit and why.
+-   Moderation Team members may Remove or Block an individual from the expressjs GitHub Organizations.
+-   For any Removal or Blocking action, an issue describing the reasons for the action, and identifying the Github account being acted upon, must be posted to the Moderation Repository with an explanation provided by the Moderation Team member performing the action.
+-   Any individual Blocked from the expressjs, jshttp, and pillarjs organizations will be recommended for exclusion from any OpenJS Foundation sponsored event or activity.
+-   Minor edits to the formatting of a Post or to correct typographical errors are not "Moderation". Such edits and their intent must still be documented with a short note indicating who made the edit and why.
 
 ### Collaborator Posts
 
--   Prior to Moderating any Post authored by a Collaborator, the author must be
-    given a reasonable opportunity to modify or remove the Post on their own.
--   If the author of the Post disagrees that Moderation is required, the matter
-    can be escalated to the Moderation Team for resolution. In such cases, no
-    Moderation action may be taken until a decision by the Moderation Team is
-    made.
--   When Moderating any Post authored by another Collaborator, the moderating
-    Collaborator must:
+-   Prior to Moderating any Post authored by a Collaborator, the author must be given a reasonable opportunity to modify or remove the Post on their own.
+-   If the author of the Post disagrees that Moderation is required, the matter can be escalated to the Moderation Team for resolution. In such cases, no Moderation action may be taken until a decision by the Moderation Team is made.
+-   When Moderating any Post authored by another Collaborator, the moderating Collaborator must:
     -   Explain the justification for Moderating the post,
     -   Identify all changes made to the Post, and
     -   Identify the steps previously taken to resolve the issue.
-    -   If the Moderation action included Blocking, an indication of whether the Block
-        is temporary or indefinite is required, along with an issue posted to the
-        moderation repository justifying the action.
+    -   If the Moderation action included Blocking, an indication of whether the Block is temporary or indefinite is required, along with an issue posted to the moderation repository justifying the action.
 -   Explanations of Moderation actions on Collaborator Posts must be provided in:
     -   A new post within the original thread, or
     -   A new issue within the private expressjs/moderation repository.
--   Any Collaborator habitually violating the Code of Conduct or this Moderation
-    policy may be Blocked temporarily or, in extreme cases, Removed and Blocked
-    indefinitely.
+-   Any Collaborator habitually violating the Code of Conduct or this Moderation policy may be Blocked temporarily or, in extreme cases, Removed and Blocked indefinitely.
 
 ### Non-Collaborator Posts
 
--   Posts authored by non-Collaborators are always subject to immediate Moderation
-    by any Collaborator if the content is intentionally disruptive or in violation
-    of the [Code of Conduct][].
+-   Posts authored by non-Collaborators are always subject to immediate Moderation by any Collaborator if the content is intentionally disruptive or in violation of the [Code of Conduct][].
 -   When moderating non-Collaborator posts, the moderating Collaborator must:
     -   Explain the justification for Moderating the post, and
     -   Identify all changes made to the Post.
-    -   If the Moderation action included Blocking, an indication of whether the Block
-        is temporary or indefinite is required, along with a note justifying the
-        action.
--   If an explanation of a Moderation action for a non-Collaborator Post is
-    provided, it must be provided in:
+    -   If the Moderation action included Blocking, an indication of whether the Block is temporary or indefinite is required, along with a note justifying the action.
+-   If an explanation of a Moderation action for a non-Collaborator Post is provided, it must be provided in:
     -   The original Post being modified (as replacement or appended content),
     -   A new post within the original thread, or
     -   A new issue within the private expressjs/moderation repository.
--   Moderation of Posts authored by non-Collaborators may result in those
-    non-Collaborators being Blocked temporarily or indefinitely from further
-    participation in the expressjs GitHub organization.
--   If it is clear that there is no intention to collaborate in good faith,
-    it is possible to hide comments of non-Collaborators. In that case there is
-    an exception to the reporting requirement described above.
--   Accounts that are reasonably believed to be bots (other than bots authorized
-    by the TC) are subject to immediate Blocking.
--   Issues, pull requests, discussions, and comments that are spam (job posting,
-    service advertising, etc.) are subject to immediate moderation.
--   Collaborators may use the Hide feature in the GitHub interface for off-topic
-    posts by non-Collaborators.
--   Moderation Team members and TC voting members can delete any issues or
-    comments posted by accounts that have been deleted by GitHub. These accounts
-    show up in the GitHub interface as user `ghost`. There is no need to
-    screenshot or document these deletions.
+-   Moderation of Posts authored by non-Collaborators may result in those non-Collaborators being Blocked temporarily or indefinitely from further participation in the expressjs GitHub organization.
+-   If it is clear that there is no intention to collaborate in good faith, it is possible to hide comments of non-Collaborators. In that case there is an exception to the reporting requirement described above.
+-   Accounts that are reasonably believed to be bots (other than bots authorized by the TC) are subject to immediate Blocking.
+-   Issues, pull requests, discussions, and comments that are spam (job posting, service advertising, etc.) are subject to immediate moderation.
+-   Collaborators may use the Hide feature in the GitHub interface for off-topic posts by non-Collaborators.
+-   Moderation Team members and TC voting members can delete any issues or comments posted by accounts that have been deleted by GitHub. These accounts show up in the GitHub interface as user `ghost`. There is no need to screenshot or document these deletions.
 
 There are a few examples of moderating non-Collaborator posts:
 
@@ -200,65 +130,43 @@ Scenario 2:
 -   A non-Collaborator posts a comment that is against the Code of Conduct.
 -   A Collaborator sees the comment and asks the author to edit it.
 -   The author refuses to edit their comment.
--   The Collaborator deletes the comment and posts an issue in the moderation
-    repository explaining their actions.
+-   The Collaborator deletes the comment and posts an issue in the moderation repository explaining their actions.
 
 Scenario 3:
 
--   A non-Collaborator opens a pull request with comments indicating they are a
-    bot.
--   A Collaborator sees that pull requests, closes it, deletes the comments
-    and posts an issue in the moderation repository explaining their actions.
--   A moderation team member sees the issue and decides to block the user from the
-    organization.
+-   A non-Collaborator opens a pull request with comments indicating they are a bot.
+-   A Collaborator sees that pull requests, closes it, deletes the comments and posts an issue in the moderation repository explaining their actions.
+-   A moderation team member sees the issue and decides to block the user from the organization.
 
 Scenario 4:
 
--   A non-Collaborator posts a comment on an old commit that is against the
-    Code of Conduct.
+-   A non-Collaborator posts a comment on an old commit that is against the Code of Conduct.
 -   A Collaborator sees the comment, takes a screenshot, and deletes it.
--   The Collaborator posts an issue in the moderation repository explaining
-    their actions.
+-   The Collaborator posts an issue in the moderation repository explaining their actions.
 
 ### Temporary Interaction Limits
 
-The Moderation Team may, at their discretion, choose to enable [GitHub's
-Temporary Interaction Limits][] on any GitHub repository in the expressjs, jshttp, and pillarjs GitHub Organizations.
+The Moderation Team may, at their discretion, choose to enable [GitHub's Temporary Interaction Limits][] on any GitHub repository in the expressjs, jshttp, and pillarjs GitHub Organizations.
 
-Any Collaborator may request that the Moderation Team enable the Temporary
-Interaction Limits by posting an issue to the moderation repository. If the
-Moderation Team chooses not to do so, then a comment explaining why that
-decision was made must be added to the moderation repository thread.
+Any Collaborator may request that the Moderation Team enable the Temporary Interaction Limits by posting an issue to the moderation repository. If the Moderation Team chooses not to do so, then a comment explaining why that decision was made must be added to the moderation repository thread.
 
 ### Temporary and Indefinite Blocks
 
-A Temporary Block is time limited, with the timeframe decided on by the Moderation
-Team at the time of issuing, depending on the severity of the issue. Recommended
-default options are 24-hour, 48-hour, and 7-day periods.
+A Temporary Block is time limited, with the timeframe decided on by the Moderation Team at the time of issuing, depending on the severity of the issue. Recommended default options are 24-hour, 48-hour, and 7-day periods.
 
-An Indefinite Block is set for an unspecified period of time and may only be
-lifted for an individual through a simple majority vote of the Moderation
-Team.
+An Indefinite Block is set for an unspecified period of time and may only be lifted for an individual through a simple majority vote of the Moderation Team.
 
 ## Privacy of the expressjs/moderation Repository
 
-The expressjs/moderation Repository is used to discuss the potentially sensitive
-details of any specific moderation issue. The repository is private but
-accessible to all Collaborators. The details of any issue discussed within the
-expressjs/moderation repository are expected to remain confidential and are not to
-be discussed in any public forum or social media service.
+The expressjs/moderation Repository is used to discuss the potentially sensitive details of any specific moderation issue. The repository is private but accessible to all Collaborators. The details of any issue discussed within the expressjs/moderation repository are expected to remain confidential and are not to be discussed in any public forum or social media service.
 
-Any Collaborator found to be violating the privacy of the expressjs/moderation
-repository by repeatedly sharing or discussing the details of expressjs/moderation
-issues in any public forum or social media service risks being permanently
-removed from the expressjs GitHub organization.
+Any Collaborator found to be violating the privacy of the expressjs/moderation repository by repeatedly sharing or discussing the details of expressjs/moderation issues in any public forum or social media service risks being permanently removed from the expressjs GitHub organization.
 
 ## Moderation Team
 
 The expressjs Moderation Team is tasked with enforcement of this policy.
 
-At least once per month, the Moderation Team must provide a report of all Moderation
-actions taken by the Moderation Team to the TC.
+At least once per month, the Moderation Team must provide a report of all Moderation actions taken by the Moderation Team to the TC.
 
 _Requirements_
 
@@ -268,11 +176,7 @@ _Requirements_
 
 _Nomination_
 
-Moderation team members are Collaborators who self-nominate or are nominated by
-the TC. Team members must be approved by the TC with annual
-recertification. If there are no objections after seven days, the nomination is automatically
-accepted. If there are objections to a specific nomination, then a TC vote
-in favor of the nomination is required.
+Moderation team members are Collaborators who self-nominate or are nominated by the TC. Team members must be approved by the TC with annual recertification. If there are no objections after seven days, the nomination is automatically accepted. If there are objections to a specific nomination, then a TC vote in favor of the nomination is required.
 
 _Onboarding_
 
@@ -285,8 +189,7 @@ New Moderation Team members are onboarded with:
 
 _Recertification_
 
-An annual recertification vote is required for all Moderation Team members.
-For an individual to be recertified, a TC vote in favor of recertification is required.
+An annual recertification vote is required for all Moderation Team members. For an individual to be recertified, a TC vote in favor of recertification is required.
 
 _Departure_
 
@@ -294,10 +197,7 @@ A TC vote is required to remove a moderator who has not resigned.
 
 _Resignation_
 
-At any time a Moderation Team member may notify the team that they will no longer be serving.
-Either the resigning member or an active member will file an issue notifying the Admin group
-that the team member is stepping down. An active team member will take necessary steps to
-remove resigning team member from respective permissions and private access.
+At any time a Moderation Team member may notify the team that they will no longer be serving. Either the resigning member or an active member will file an issue notifying the Admin group that the team member is stepping down. An active team member will take necessary steps to remove resigning team member from respective permissions and private access.
 
 <!-- referenced from the CoC page -->
 
@@ -305,33 +205,20 @@ remove resigning team member from respective permissions and private access.
 
 ### Current Members of Moderation Team
 
--   [IamLizu](https://github.com/IamLizu) -
-    **S M Mahmudul Hasan** <<he@smmahmudulhasan.com>> (he/him)
+
 
 ## Escalation of Issues
 
-Moderation issue disputes not involving a TC voting member or Moderation Team
-member may be escalated to the TC for review by tagging the
-original issue, pull request, or associated expressjs/moderation repository
-tracking issue with the `moderation-review` label. Any such Moderation action
-may be overturned through a TC vote.
+Moderation issue disputes not involving a TC voting member or Moderation Team member may be escalated to the TC for review by tagging the original issue, pull request, or associated expressjs/moderation repository tracking issue with the `moderation-review` label. Any such Moderation action may be overturned through a TC vote.
 
-TC or Moderation Team members directly involved in a Moderation
-issue (as either the Requester or author of the Post in question) are
-required to recuse themselves from any decisions required to resolve the
+TC or Moderation Team members directly involved in a Moderation issue (as either the Requester or author of the Post in question) are required to recuse themselves from any decisions required to resolve the
 issue.
 
-Moderation disputes involving TC or Moderation Team members,
-including questions of whether a TC or Moderation Team member has
-violated the Code of Conduct, _shall_ be referred to an Independent Mediator
-selected by the OpenJS Foundation.
+Moderation disputes involving TC or Moderation Team members, including questions of whether a TC or Moderation Team member has violated the Code of Conduct, _shall_ be referred to an Independent Mediator selected by the OpenJS Foundation.
 
 ## Modifications to This Policy
 
-Modifications to this policy are subject to approval by the TC.
-When modifications are proposed, if there are no objections after
-72 hours, the modifications are accepted. If there any objections to
-any proposed change, a TC vote in favor of the change is required.
+Modifications to this policy are subject to approval by the TC. When modifications are proposed, if there are no objections after 72 hours, the modifications are accepted. If there any objections to any proposed change, a TC vote in favor of the change is required.
 
 [Code of Conduct]: https://github.com/expressjs/express/blob/master/Code-Of-Conduct.md
 [expressjs Technical Committee]: https://github.com/expressjs/express/blob/master/Readme.md#tc-technical-committee

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -1,6 +1,6 @@
 # Moderation policy
 
-If you are not a member of the s and wish to submit a
+If you are not a member and wish to submit a
 moderation request, please see [Requesting Moderation][].
 
 -   [Applicability][]

--- a/ModerationPolicy.md
+++ b/ModerationPolicy.md
@@ -83,7 +83,7 @@ Note, however, that unfamiliarity with the [Code of Conduct][] does not excuse a
 -   Moderation Team members may Remove or Block an individual from the expressjs GitHub Organizations.
 -   For any Removal or Blocking action, an issue describing the reasons for the action, and identifying the Github account being acted upon, must be posted to the Moderation Repository with an explanation provided by the Moderation Team member performing the action.
 -   Any individual Blocked from the expressjs, jshttp, and pillarjs organizations will be recommended for exclusion from any OpenJS Foundation sponsored event or activity.
--   Minor edits to the formatting of a Post or to correct typographical errors are not "Moderation". Such edits and their intent must still be documented with a short note indicating who made the edit and why.
+-   Minor edits to the formatting of a Post or to correct typographical errors are not "Moderation". Such edits and their intent must still be documented with a short note indicating the reason.
 
 ### Collaborator Posts
 


### PR DESCRIPTION
As discussed in [GitHub issue #270](https://github.com/expressjs/discussions/issues/270), this pull request presents a draft of the Moderation Policy for the _expressjs_, _jshttp_, and _pillarjs_ GitHub organizations. This draft is largely based on the [Node.js Moderation Policy](https://github.com/nodejs/admin/blob/main/Moderation-Policy.md), as most of its provisions are deemed suitable for the our organizations.

While the entire document is open for review, I request particular attention to the following items,

1. The scope of this moderation policy mentions only the GitHub organizations unlike Nodejs, as they have Slack and other communities in scope.
2. Following Nodejs, I have kept the process of requesting moderation via email, and suggested an example email address as _report@expressjs.com_. 
    - If we decide to not have this approach, we can simply remove the relevant parts of this process.
    - Otherwise, a mailbox creation is suggested. 
3. `expressjs/moderation` repository should be the home for discussing things related to moderation and a place for moderation requests. 
    - If we have the repository, all collaborators should be added.
    - Otherwise, suggesting to create the repository.
    -  A label `moderation-review` to escalate issues
4. I have added a _Requirements_ section in addition to the existing process of being a Moderator as mentioned in Nodejs model,
    - Must be a Collaborator in the expressjs GitHub organization.
    - Active participation in the expressjs/moderation repository.
    - Show a commitment to the expressjs Code of Conduct.


### Notes
- Fixes https://github.com/expressjs/discussions/issues/270